### PR TITLE
add a much simpler changelog API

### DIFF
--- a/zeus/changelog/simple_changelog.py
+++ b/zeus/changelog/simple_changelog.py
@@ -1,0 +1,98 @@
+import graphene
+from zeus.graphql.internal_query_executor_base import InternalQueryExecutorBase
+from zeus.changelog.graphql.util import (
+    convert_enum_list_to_dict,
+    create_model_enum_type,
+    create_model_field_enum_type,
+    create_standard_changelog_graphql_mixin,
+)
+
+
+base_query = """
+    query ChangelogQuery(
+        $page_num :Int!
+        $user_ids: [Int]
+        $models:[ChangelogModels]
+        $fields: [ChangelogModelFields]
+        $exclude_create: Boolean!
+        $only_creates: Boolean!
+        $start_date: DateTime
+        $end_date: DateTime
+    ) {
+        changelog(
+            page_num:$page_num,
+            user_ids: $user_ids,
+            models: $models,
+            fields: $fields,
+            exclude_create: $exclude_create,
+            only_creates: $only_creates,
+            start_date: $start_date,
+            end_date: $end_date,
+        ){
+            has_next_page
+            changelog_entries {
+                model_name
+                version {
+                    instance
+                    edited_by
+                }
+                eternal
+                live_name
+                diffs {
+                    field
+                    field_name
+                    action
+                    diffed_before
+                    diffed_after
+                    diffed_combined
+                }
+            }
+        }
+    }
+"""
+
+
+def create_simple_changelog(models, page_size=None):
+    RootQuery = create_standard_changelog_graphql_mixin(
+        diffable_models=models, page_size=page_size
+    )
+    changelog_schema = graphene.Schema(query=RootQuery, auto_camelcase=False)
+
+    class QueryExecutor(InternalQueryExecutorBase):
+        schema = changelog_schema
+
+    query_executor = QueryExecutor()
+
+    return ChangelogContainer(query_executor)
+
+
+class ChangelogContainer:
+    def __init__(self, query_executor):
+        self.query_executor = query_executor
+
+    def get_page(
+        self,
+        page_num,
+        models=None,
+        user_ids=None,
+        fields=None,
+        exclude_create=False,
+        only_creates=False,
+        start_date=None,
+        end_date=None,
+    ):
+
+        page = self.query_executor.execute_query(
+            base_query,
+            variables={
+                "page_num": page_num,
+                "models": models,
+                "user_ids": user_ids,
+                "fields": fields,
+                "exclude_create": exclude_create,
+                "only_creates": only_creates,
+                "start_date": start_date,
+                "end_date": end_date,
+            },
+        )
+        return page["changelog"]

--- a/zeus/changelog/simple_changelog.py
+++ b/zeus/changelog/simple_changelog.py
@@ -1,12 +1,12 @@
 import graphene
-from zeus.graphql.internal_query_executor_base import InternalQueryExecutorBase
+
 from zeus.changelog.graphql.util import (
     convert_enum_list_to_dict,
     create_model_enum_type,
     create_model_field_enum_type,
     create_standard_changelog_graphql_mixin,
 )
-
+from zeus.graphql.internal_query_executor_base import InternalQueryExecutorBase
 
 base_query = """
     query ChangelogQuery(

--- a/zeus/changelog/tests/test_simple_changelog.py
+++ b/zeus/changelog/tests/test_simple_changelog.py
@@ -1,0 +1,48 @@
+from django_sample.models import Author, Book, Tag
+
+from zeus.changelog.simple_changelog import create_simple_changelog
+
+
+def test_simple_changelog():
+    author1 = Author.objects.create(first_name="john", last_name="smith")
+    author2 = Author.objects.create(first_name="jane", last_name="smith")
+    book1 = Book.objects.create(author=author1, title="john's diary")
+
+    book1_v1 = book1.versions.last()
+
+    # refresh a new copy of this record to avoid history-row re-use
+    book1.reset_version_attrs()
+    book1.title = "jane's diary"
+    book1.author = author2
+    book1.save()
+
+    book1_v2 = book1.versions.last()
+
+    changelog = create_simple_changelog(models=[Author, Book], page_size=2)
+
+    data = changelog.get_page(1)
+    edit_entries = data["changelog_entries"]
+    assert len(edit_entries) == 2
+
+    assert edit_entries[0]["version"]["instance"] == book1_v2
+    assert len(edit_entries[0]["diffs"]) == 2
+    diffs_by_fields = {diff["field_name"]: diff for diff in edit_entries[0]["diffs"]}
+
+    # field-diffs might come in any order
+    assert set(diffs_by_fields.keys()) == {
+        "title",
+        "author",
+    }
+    # they have field objects as well
+    assert diffs_by_fields["title"]["field"] == Book._meta.get_field("title")
+
+    assert edit_entries[1]["version"]["instance"] == book1_v1
+
+    # this field returns a tm() result
+    assert edit_entries[1]["diffs"][0]["action"] == "Created"
+
+    assert edit_entries[0]["eternal"] == edit_entries[1]["eternal"] == book1
+    assert edit_entries[0]["model_name"] == "book"
+
+    assert data["has_next_page"] == True
+

--- a/zeus/changelog/tests/test_simple_changelog.py
+++ b/zeus/changelog/tests/test_simple_changelog.py
@@ -1,5 +1,4 @@
 from django_sample.models import Author, Book, Tag
-
 from zeus.changelog.simple_changelog import create_simple_changelog
 
 
@@ -45,4 +44,3 @@ def test_simple_changelog():
     assert edit_entries[0]["model_name"] == "book"
 
     assert data["has_next_page"] == True
-


### PR DESCRIPTION
now you can create changelogs without dealing with graphql directly:


```python
    from zeus.changelog.simple_changelog import create_simple_changelog
    
    from django_sample.models import Author, Book, Tag

    changelog = create_simple_changelog(models=[Author, Book], page_size=2)

    data = changelog.get_page(1)
```

It uses graphql under the hood, so you still need all the graphene dependencies

```ini
graphene==2.1.8
graphene-django==2.10.1
```