### PR TITLE
Fix missing yaml and missing num_pages in changelog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setuptools.setup(
         for package in setuptools.find_packages()
         if package.startswith("zeus")
     ],
+    package_data={"": ["**/*.text.yaml"]},
+    include_package_data=True,
     install_requires=[],
     tests_require=["django"],
     classifiers=[

--- a/zeus/changelog/simple_changelog.py
+++ b/zeus/changelog/simple_changelog.py
@@ -29,6 +29,7 @@ base_query = """
             start_date: $start_date,
             end_date: $end_date,
         ){
+            num_pages
             has_next_page
             changelog_entries {
                 model_name


### PR DESCRIPTION
there are some `tm` functions being created within zeus with yaml files within zeus, but they weren't being added to consumer's install directories, so I added that to the `setup.py`.

Also, I forgot to add `num_pages` to the simple-changelog output