### PR TITLE
pass choices down to version model

### DIFF
--- a/zeus/versioning/core.py
+++ b/zeus/versioning/core.py
@@ -153,6 +153,8 @@ def create_version_field_from_live_field(field):
         new_field = clone_with_unique_false(field)
         new_field.primary_key = False
 
+    new_field.choices = field.choices
+
     return name, new_field
 
 


### PR DESCRIPTION
The main reason for this is so that we get the hooks `instance.get_field_name_display()` on the version model which should make it easier to display (or maybe export) versions, at least some of the time.