### PR TITLE
Add default of [] for non-nullable m2m versioning fields

### DIFF
--- a/zeus/versioning/core.py
+++ b/zeus/versioning/core.py
@@ -226,7 +226,7 @@ class VersionModelMeta(ModelBase):
     def _create_m2m_fields(version_cls, live_model):
         m2m_fields_to_add = {}
         for field in version_cls.get_m2m_fields_to_version():
-            new_field = models.JSONField()
+            new_field = models.JSONField(null=True)
             m2m_fields_to_add[field.name] = new_field
 
         return m2m_fields_to_add

--- a/zeus/versioning/core.py
+++ b/zeus/versioning/core.py
@@ -109,6 +109,10 @@ class HistoryManager(Manager):
         ).only_most_recent_versions()
 
 
+def m2m_default_empty_list():
+    return [] 
+
+
 def create_version_field_from_live_field(field):
     name = field.attname
 
@@ -226,7 +230,7 @@ class VersionModelMeta(ModelBase):
     def _create_m2m_fields(version_cls, live_model):
         m2m_fields_to_add = {}
         for field in version_cls.get_m2m_fields_to_version():
-            new_field = models.JSONField(null=True)
+            new_field = models.JSONField(default=m2m_default_empty_list)
             m2m_fields_to_add[field.name] = new_field
 
         return m2m_fields_to_add

--- a/zeus/versioning/core.py
+++ b/zeus/versioning/core.py
@@ -110,7 +110,7 @@ class HistoryManager(Manager):
 
 
 def m2m_default_empty_list():
-    return [] 
+    return []
 
 
 def create_version_field_from_live_field(field):


### PR DESCRIPTION
I noticed adding a m2m field on a class prevented me from creating a migration, because the json field is created as non-nullable and there may already be records in the database.
Should we... 
- make the JSON fields nullable
- use a default of `""`
- use a default of an empty list, e.g. `"[]"`

Still have to play around with those options
